### PR TITLE
Corrigindo Erro de Imagens PNG não aparecerem

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     },
     output: 'export',
     trailingSlash: true, 
-    basePath: '/exonera'
+    basePath: '/exoonero'
     
 }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer(){
     return (
         <footer className="flex text-xs text-[#6C6C6C] gap-x-5 items-center ">
-          <img  className="w-24" src="https://alex-custodio.github.io/exoonero/creative-commons.png"/>
+          <img  className="w-24" src="https://exoonero.github.io/site/creative-commons.png"/>
           <p>
             Dados públicos extraídos de diários oficiais municipais da
             Associação dos Municípios Alagoanos (AMA). Todo o conteúdo do site

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -42,7 +42,7 @@ export function MainLayout({ children, activeButton}: MainLayoutProps) {
                 Confira as nomeações e exonerações de Alagoas
               </h1>
               <div className="flex gap-x-3 items-center">
-                <img className="3xl:w-[7.56rem] lg:w-[6.301rem] 3xl:h-[2.31rem] lg:h-[1.92rem]" src="https://alex-custodio.github.io/exoonero/img-profiles.png"/>
+                <img className="3xl:w-[7.56rem] lg:w-[6.301rem] 3xl:h-[2.31rem] lg:h-[1.92rem]" src="https://exoonero.github.io/site/img-profiles.png"/>
                 <p className="text-white lg:text-base leading-4 font-normal ">
                   Juntos por uma sociedade mais transparente e participativa
                 </p>
@@ -70,7 +70,7 @@ export function MainLayout({ children, activeButton}: MainLayoutProps) {
             </div>
             <img
               className="absolute 3xl:max-w-none lg:-bottom-[18rem] md:-bottom-[200rem] lg:scale-75 xl:-bottom-[19rem] xl:scale-[.62] 2xl:scale-75  min-[1920]:scale-100 3xl:-bottom-[28rem] left-2 3xl:-left-[6rem]"
-              src="https://alex-custodio.github.io/exoonero/girl-icon.png"/>
+              src="https://exoonero.github.io/site/girl-icon.png"/>
           </aside>
         </div>
         <main className="bg-[#F5F7FB]  w-full overflow-y-auto px-[2.875rem] pt-[3.25rem] pb-6 ">


### PR DESCRIPTION
Só pra explicar isso das imagens: o github pages atualmente não tem suporte ao componente Image usado pelo next pra colocar imagens, então pro github pages tive que modificar as Images para a tag img normal e colocar o caminho absoluto da imagem no site.

Como o endereço do repositório mudou, o caminho absoluto deve mudar também.
