### PR TITLE
Corrigindo Problema com a Imagem da girlIcon

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -79,7 +79,7 @@ export function MainLayout({ children, activeButton }: MainLayoutProps) {
               </div>
             </div>
             <img
-              className="absolute 3xl:max-w-none lg:-bottom-[18rem] md:-bottom-[200rem] lg:scale-[.62] xl:-bottom-[19rem] 2xl:scale-[.68] min-[1920]:scale-[.95] 3xl:-bottom-[28rem] left-2 3xl:-left-[6rem]"
+              className="absolute hidden 2xl:block 3xl:max-w-none lg:-bottom-[18rem] md:-bottom-[200rem] lg:scale-[.62] xl:-bottom-[19rem] 2xl:scale-[.68] min-[1920]:scale-[.95] 3xl:-bottom-[28rem] left-2 3xl:-left-[6rem]"
               src="https://exoonero.org/girl-icon.png"
             />
           </aside>


### PR DESCRIPTION
Atualmente, em monitores com resolução menor que 1536px a imagem da girlIcon está por cima dos elementos.
![image](https://github.com/exoonero/exoonero.github.io/assets/89322317/364a5742-f978-4f02-b4f4-ff6f6e1bbbd1)


Essa PR faz com que nessas telas menores, a imagem não apareça para não causar isso:

![image](https://github.com/exoonero/exoonero.github.io/assets/89322317/3efa9527-0a21-4ab8-9408-a8f0210bd244)

Nas telas a partir de 1536px a imagem irá aparecer.
